### PR TITLE
handler for ChanVariable / channelvars

### DIFF
--- a/lib/ami.js
+++ b/lib/ami.js
@@ -160,8 +160,15 @@ AMIParser.prototype._transform = function(chunk, encoding, done){
                     value = lines[lineIndex].slice(foundColon+1).trim();
 
                     if(key.length > 0){
-                        // add key, value to object
-                        messajeJson[key] = value;
+                        // handle ChanVariable sets
+                        if (key == "ChanVariable") {
+                                value = value.split('=');
+                                // add subkey, subvalue to object
+                                messajeJson[value[0]] = value[1];
+                        } else {
+                                // add key, value to object
+                                messajeJson[key] = value;
+                        }
                     }
                 } else {
                     // not a good line message, do nothing with it


### PR DESCRIPTION
This minor patch implements an inline handler to support sequential channelvars pairs, when configured in manager.conf
```
[general]
channelvars=id_session,test
```